### PR TITLE
Remove SGX.com scraper

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,6 @@ For researchers, a curated list of academic work from computer conferences is he
 - **SGX + Snort Intrusion Detection System** [https://github.com/cloud-security-research/sgx-ids](https://github.com/cloud-security-research/sgx-ids)
 - **SafeBricks: Shielding Network Functions in the Cloud (NSDI 2018)** [https://github.com/YangZhou1997/SafeBricks](https://github.com/YangZhou1997/SafeBricks)
 - **SGX + Tor (NSDI 2017)** [https://github.com/kaist-ina/SGX-Tor](https://github.com/kaist-ina/SGX-Tor)
-- **SGX + Web Crawler** [https://github.com/ShengHow95/simple-selenium-sgx-crawler](https://github.com/ShengHow95/simple-selenium-sgx-crawler)
 
 ## Data Analytics
 


### PR DESCRIPTION
This is not relevant to SGX. It's a scrape for the SGX.com website which is not related to Intel SGX. It is not a scraper in a tee